### PR TITLE
Replace ComptimeStringMap with StaticStringMap

### DIFF
--- a/src/zmd/tokens.zig
+++ b/src/zmd/tokens.zig
@@ -66,13 +66,10 @@ pub const elements = [_]Element{
     .{ .type = .ordered_list_item, .syntax = "1. ", .close = .linebreak, .clear = true },
 };
 
-pub const toggles = std.ComptimeStringMap(
-    Element,
-    .{
-        .{ "code", .{ .type = .code_close, .syntax = "`" } },
-        .{ "block", .{ .type = .block_close, .syntax = "```" } },
-    },
-);
+pub const toggles = std.StaticStringMap(Element).initComptime(.{
+    .{ "code", .{ .type = .code_close, .syntax = "`" } },
+    .{ "block", .{ .type = .block_close, .syntax = "```" } },
+});
 
 pub const formatters = [_]Element{
     .{ .type = .bold, .syntax = "**", .close = .bold_close },


### PR DESCRIPTION
**Note: I'm not familiar with every inner working of this library, please test before merging.**

The nightly zig std renamed ComptimeStringMap to StaticStringMap, with some small changes. This commit updates the codebase to be compatible with the latest changes.
Reference: ziglang/zig#19719

<img src="https://github.com/Avdan-OS/Compositor/assets/51555391/d0379882-f2dc-42e1-962f-b3f122db656f" alt="vibe" width="60"/>