### PR TITLE
Improve parsing time for repeated whitespace

### DIFF
--- a/src/tests/general.zig
+++ b/src/tests/general.zig
@@ -227,3 +227,11 @@ test "parse underscores in block" {
         \\
     , html);
 }
+
+test "parse repeated whitespace" {
+    var zmd = Zmd.init(std.testing.allocator);
+    defer zmd.deinit();
+
+    // Used to be really slow
+    try zmd.parse(" " ** 40_000);
+}


### PR DESCRIPTION
`firstToken` calls `isCleared` for each character. Before this change, `isCleared` always walked back to the first non-whitespace character. After this change, the result from the last `isCleared` call is saved, and a subsequent call only needs to check a few characters.