### PR TITLE
Fixing Enum value of "fn", "struct" to "Fn", "Struct" in accordance to zig 13.0

### DIFF
--- a/src/zmd/Node.zig
+++ b/src/zmd/Node.zig
@@ -79,8 +79,8 @@ pub fn getFormatterComptime(fragments: type, comptime element_type: []const u8) 
         html.DefaultFragments.default;
 
     return switch (@typeInfo(@TypeOf(formatter))) {
-        .@"fn" => Formatter{ .function = &formatter },
-        .@"struct" => Formatter{ .array = formatter },
+        .@"Fn" => Formatter{ .function = &formatter },
+        .@"Struct" => Formatter{ .array = formatter },
         else => unreachable,
     };
 }


### PR DESCRIPTION
Hello, the tests cases are failing on Zig 13.0 due to enum values of Type being renamed:
- `"fn"` → `"Fn"`
- `"struct"` → `"Struct"`

Had also created an issue for this: [https://github.com/jetzig-framework/zmd/issues/3](url)

All test cases are passing after applying this change.

Fixes #3

