### PR TITLE
Fixing tests for Zig 0.13.0

### DIFF
--- a/src/zmd/Node.zig
+++ b/src/zmd/Node.zig
@@ -79,8 +79,8 @@ pub fn getFormatterComptime(fragments: type, comptime element_type: []const u8) 
         html.DefaultFragments.default;
 
     return switch (@typeInfo(@TypeOf(formatter))) {
-        .@"fn" => Formatter{ .function = &formatter },
-        .@"struct" => Formatter{ .array = formatter },
+        .Fn => Formatter{ .function = &formatter },
+        .Struct => Formatter{ .array = formatter },
         else => unreachable,
     };
 }


### PR DESCRIPTION
I was trying to run the library tests with latest stable Zig and got a few errors. Switching up the meta-programming switch cases fixed it.