### PR TITLE
feat: support asterisk syntax for italics (*text*)

### DIFF
--- a/src/tests/elements.zig
+++ b/src/tests/elements.zig
@@ -246,6 +246,56 @@ test "italic (embedded)" {
     try expectEqualStrings(html, parsed);
 }
 
+test "italic with asterisks (dangling)" {
+    const html =
+        \\<!DOCTYPE html>
+        \\<html>
+        \\<head>
+        \\  <meta charset="utf8">
+        \\</head>
+        \\<body>
+        \\<main>
+        \\<p><i>italic</i></p>
+        \\</main>
+        \\</body>
+        \\</html>
+        \\
+    ;
+
+    const md =
+        \\*italic*
+    ;
+
+    const parsed = try zmd.parse(allocator, md, .{});
+    defer allocator.free(parsed);
+    try expectEqualStrings(html, parsed);
+}
+
+test "italic with asterisks (embedded)" {
+    const html =
+        \\<!DOCTYPE html>
+        \\<html>
+        \\<head>
+        \\  <meta charset="utf8">
+        \\</head>
+        \\<body>
+        \\<main>
+        \\<p>some <i>italic</i> text</p>
+        \\</main>
+        \\</body>
+        \\</html>
+        \\
+    ;
+
+    const md =
+        \\some *italic* text
+    ;
+
+    const parsed = try zmd.parse(allocator, md, .{});
+    defer allocator.free(parsed);
+    try expectEqualStrings(html, parsed);
+}
+
 test "code (dangling)" {
     const html =
         \\<!DOCTYPE html>

--- a/src/zmd/tokens.zig
+++ b/src/zmd/tokens.zig
@@ -76,6 +76,7 @@ pub const toggles = std.StaticStringMap(Element).initComptime(
 pub const formatters = [_]Element{
     .{ .type = .bold, .syntax = "**", .close = .bold_close },
     .{ .type = .italic, .syntax = "_", .close = .italic_close },
+    .{ .type = .italic, .syntax = "*", .close = .italic_close },
 };
 
 pub const Linebreak = Element{ .type = .linebreak };


### PR DESCRIPTION
## Summary

Adds support for `*italic*` syntax in addition to `_italic_`. This is standard Markdown behavior - most Markdown parsers support both syntaxes for emphasis.

## Changes

- Added `*` as an alternative syntax for italics in the `formatters` array in `tokens.zig`
- Added test cases for asterisk italics (dangling and embedded)

## Why

Standard Markdown spec allows both `*text*` and `_text_` for italic/emphasis. Currently zmd only supports underscores, which can be surprising for users coming from other Markdown parsers.

The implementation is simple because:
- `**` (bold) is already handled and listed first in formatters, so it matches before single `*`
- `* ` (list item) is a block-level element handled separately

## Testing

All existing tests pass, plus new test cases for asterisk italics.